### PR TITLE
Issues #603 and #604 are now fixed

### DIFF
--- a/build/reference/0102umpleTools.txt
+++ b/build/reference/0102umpleTools.txt
@@ -12,7 +12,7 @@ and compile .ump files.</p>
 
 <li><b>Eclipse.</b> To use Umple with Eclipse, you need to load an Umple 
 Eclipse plugin. This can be obtained from our <a 
-href="http://code.google.com/p/umple/downloads/list">downloads site</a>. 
+href="https://github.com/umple/Umple/releases/tag/v.1.22.0.5146>downloads site</a>. 
 Note there is a plain plugin and a plugin enhanced with the XText 
 technology that gives context-assist to help you program or model with 
 fewer errors.</li>
@@ -28,7 +28,7 @@ code as well as several other outputs. <a href="UsingUmpleOnline.html">The Umple
 
 <li><b>Command-line based compiler</b> You can always use Umple from the 
 command line, typically from an ant script. Simply <a
-href="http://code.google.com/p/umple/downloads/list">download the latest 
+href="https://github.com/umple/Umple/releases/tag/v.1.22.0.5146">download the latest 
 officially released version of the umple jar</a>, and run it as "java -jar umple.jar *.ump".</li>
 
 <br />

--- a/cruise.umple/src/Main_Code.ump
+++ b/cruise.umple/src/Main_Code.ump
@@ -292,7 +292,7 @@ class UmpleConsoleMain
     
     optparser.acceptsAll(Arrays.asList("version", "v"), "Print out the current Umple version number");
     optparser.acceptsAll(Arrays.asList("help"), "Display the help message");
-    optparser.acceptsAll(Arrays.asList("g", "generate"), "Specify the output language: Java,Cpp,RTCpp,SimpleCpp,Php,Ruby,SQL,Ruby,Json,Ecore,TextUml,GvStateDiagram,StructureDiagram,GvClassDiagram,GvClassTraitDiagram,GvEntityRelationshipDiagram,Alloy,NuSMV,Yuml,SimpleMetrics,Uigu2").withRequiredArg().ofType(String.class);
+    optparser.acceptsAll(Arrays.asList("g", "generate"), "Specify the output language: Java,Cpp,RTCpp,SimpleCpp,Php,Ruby,SQL,Json,Ecore,TextUml,GvStateDiagram,StructureDiagram,GvClassDiagram,GvClassTraitDiagram,GvEntityRelationshipDiagram,Alloy,NuSMV,Yuml,SimpleMetrics,Uigu2").withRequiredArg().ofType(String.class);
     optparser.acceptsAll(Arrays.asList("override"), "If a output language <lang> is specified using option -g, output will only generate language <lang>");
     optparser.acceptsAll(Arrays.asList("path"), "If a output language is specified using option -g, output source code will be placed to path").withRequiredArg().ofType(String.class);
     optparser.acceptsAll(Arrays.asList("c","compile"), "Indicate to the entry class to compile, or with argument - to compile all outputfiles").withRequiredArg().ofType(String.class);


### PR DESCRIPTION
I have fixed issue #603 by removing one "Ruby" string from the command line compiler options list.
I have fixed issue #604 by updating the links in the Umple Tools page. 
The links now direct to the download page in Github. 
